### PR TITLE
Update (2022.11.22)

### DIFF
--- a/hotspot/src/cpu/loongarch/vm/assembler_loongarch.hpp
+++ b/hotspot/src/cpu/loongarch/vm/assembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1556,11 +1556,9 @@ public:
     AbstractAssembler::flush();
   }
 
-  inline void emit_int32(int);
   inline void emit_data(int x) { emit_int32(x); }
   inline void emit_data(int, RelocationHolder const&);
   inline void emit_data(int, relocInfo::relocType rtype);
-
 
   // Generic instructions
   // Does 32bit or 64bit as needed for the platform. In some sense these

--- a/hotspot/src/cpu/loongarch/vm/assembler_loongarch.inline.hpp
+++ b/hotspot/src/cpu/loongarch/vm/assembler_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2020, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,6 @@
 #include "asm/assembler.inline.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
-
-inline void Assembler::emit_int32(int x) {
-  AbstractAssembler::emit_int32(x);
-}
 
 inline void Assembler::emit_data(int x, relocInfo::relocType rtype) {
   relocate(rtype);

--- a/hotspot/src/cpu/loongarch/vm/c1_CodeStubs_loongarch_64.cpp
+++ b/hotspot/src/cpu/loongarch/vm/c1_CodeStubs_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2022, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,9 @@
 #include "nativeInst_loongarch.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "vmreg_loongarch.inline.hpp"
+#if INCLUDE_ALL_GCS
+#include "gc_implementation/g1/g1SATBCardTableModRefBS.hpp"
+#endif
 
 #define A0 RA0
 #define A3 RA3

--- a/hotspot/src/cpu/loongarch/vm/c1_Runtime1_loongarch_64.cpp
+++ b/hotspot/src/cpu/loongarch/vm/c1_Runtime1_loongarch_64.cpp
@@ -44,6 +44,9 @@
 #include "runtime/vframe.hpp"
 #include "runtime/vframeArray.hpp"
 #include "vmreg_loongarch.inline.hpp"
+#if INCLUDE_ALL_GCS
+#include "gc_implementation/g1/g1SATBCardTableModRefBS.hpp"
+#endif
 
 #define A0 RA0
 #define A1 RA1

--- a/hotspot/src/cpu/loongarch/vm/macroAssembler_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/macroAssembler_loongarch.cpp
@@ -49,6 +49,7 @@
 
 #ifdef COMPILER2
 #include "opto/compile.hpp"
+#include "opto/node.hpp"
 #endif
 
 #define A0 RA0

--- a/hotspot/src/cpu/loongarch/vm/nativeInst_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/nativeInst_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "nativeInst_loongarch.hpp"
 #include "oops/oop.inline.hpp"
@@ -32,6 +33,9 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"
+#ifdef COMPILER1
+#include "c1/c1_Runtime1.hpp"
+#endif
 
 #include <sys/mman.h>
 

--- a/hotspot/src/cpu/loongarch/vm/relocInfo_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/relocInfo_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "code/relocInfo.hpp"
+#include "compiler/disassembler.hpp"
 #include "nativeInst_loongarch.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/safepoint.hpp"

--- a/hotspot/src/cpu/mips/vm/nativeInst_mips.cpp
+++ b/hotspot/src/cpu/mips/vm/nativeInst_mips.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "code/codeCache.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "nativeInst_mips.hpp"

--- a/hotspot/src/cpu/mips/vm/relocInfo_mips.cpp
+++ b/hotspot/src/cpu/mips/vm/relocInfo_mips.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "code/relocInfo.hpp"
+#include "compiler/disassembler.hpp"
 #include "nativeInst_mips.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/safepoint.hpp"

--- a/hotspot/src/share/vm/c1/c1_LIR.cpp
+++ b/hotspot/src/share/vm/c1/c1_LIR.cpp
@@ -2134,7 +2134,9 @@ void LIR_OpConvert::print_instr(outputStream* out) const {
   print_bytecode(out, bytecode());
   in_opr()->print(out);                  out->print(" ");
   result_opr()->print(out);              out->print(" ");
-  if(tmp()->is_valid())                  tmp()->print(out); out->print(" ");
+  if(tmp()->is_valid()) {
+    tmp()->print(out);                   out->print(" ");
+  }
 }
 
 void LIR_OpConvert::print_bytecode(outputStream* out, Bytecodes::Code code) {

--- a/hotspot/src/share/vm/jfr/writers/jfrEncoders.hpp
+++ b/hotspot/src/share/vm/jfr/writers/jfrEncoders.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef SHARE_VM_JFR_WRITERS_JFRENCODERS_HPP
 #define SHARE_VM_JFR_WRITERS_JFRENCODERS_HPP
 
@@ -45,6 +51,12 @@
 #endif
 #ifdef TARGET_ARCH_aarch64
 # include "bytes_aarch64.hpp"
+#endif
+#ifdef TARGET_ARCH_loongarch
+# include "bytes_loongarch.hpp"
+#endif
+#ifdef TARGET_ARCH_mips
+# include "bytes_mips.hpp"
 #endif
 
 //

--- a/hotspot/src/share/vm/oops/oop.pcgc.inline.hpp
+++ b/hotspot/src/share/vm/oops/oop.pcgc.inline.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef SHARE_VM_OOPS_OOP_PCGC_INLINE_HPP
 #define SHARE_VM_OOPS_OOP_PCGC_INLINE_HPP
 
@@ -75,7 +81,7 @@ inline oop oopDesc::forward_to_atomic(oop p) {
     // forwarding pointer.
     oldMark = curMark;
   }
-  return forwardee();
+  return (oop) oldMark->decode_pointer();
 }
 
 #endif // SHARE_VM_OOPS_OOP_PCGC_INLINE_HPP


### PR DESCRIPTION
28846: Avoid multiple reloads of the mark oop in oopDesc::forward_to_atomic
28672: build failed with --disable-precompiled-headers on LA64 and MIPS64
28477: Fix misleading-indentation warnings