### PR TITLE
Update (2023.02.23)

### DIFF
--- a/hotspot/src/cpu/loongarch/vm/assembler_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/assembler_loongarch.cpp
@@ -415,7 +415,6 @@ void Assembler::ld_w(Register rd, Address src){
       ldx_w(dst, base, AT);
     }
   }
-//Disassembler::decode(pc()-32, pc(), tty);
 }
 
 void Assembler::ld_wu(Register rd, Address src){

--- a/hotspot/src/cpu/loongarch/vm/assembler_loongarch.hpp
+++ b/hotspot/src/cpu/loongarch/vm/assembler_loongarch.hpp
@@ -1557,8 +1557,15 @@ public:
   }
 
   inline void emit_data(int x) { emit_int32(x); }
-  inline void emit_data(int, RelocationHolder const&);
-  inline void emit_data(int, relocInfo::relocType rtype);
+  inline void emit_data(int x, relocInfo::relocType rtype) {
+    relocate(rtype);
+    emit_int32(x);
+  }
+
+  inline void emit_data(int x, RelocationHolder const& rspec) {
+    relocate(rspec);
+    emit_int32(x);
+  }
 
   // Generic instructions
   // Does 32bit or 64bit as needed for the platform. In some sense these

--- a/hotspot/src/cpu/loongarch/vm/assembler_loongarch.inline.hpp
+++ b/hotspot/src/cpu/loongarch/vm/assembler_loongarch.inline.hpp
@@ -30,14 +30,4 @@
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 
-inline void Assembler::emit_data(int x, relocInfo::relocType rtype) {
-  relocate(rtype);
-  emit_int32(x);
-}
-
-inline void Assembler::emit_data(int x, RelocationHolder const& rspec) {
-  relocate(rspec);
-  emit_int32(x);
-}
-
 #endif // CPU_LOONGARCH_VM_ASSEMBLER_LOONGARCH_INLINE_HPP

--- a/hotspot/src/cpu/loongarch/vm/jniFastGetField_loongarch_64.cpp
+++ b/hotspot/src/cpu/loongarch/vm/jniFastGetField_loongarch_64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "code/codeBlob.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"

--- a/hotspot/src/cpu/loongarch/vm/nativeInst_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/nativeInst_loongarch.cpp
@@ -37,6 +37,10 @@
 #include "c1/c1_Runtime1.hpp"
 #endif
 
+#ifndef PRODUCT
+#include "compiler/disassembler.hpp"
+#endif
+
 #include <sys/mman.h>
 
 #define A0 RA0
@@ -313,7 +317,9 @@ intptr_t NativeMovConstReg::data() const {
     return Assembler::simm12((int_at(0) >> 10) & 0xfff);
   }
 
+#ifndef PRODUCT
   Disassembler::decode(addr_at(0), addr_at(0) + 16, tty);
+#endif
   fatal("not a mov reg, imm52");
   return 0; // unreachable
 }

--- a/hotspot/src/cpu/loongarch/vm/sharedRuntime_loongarch_64.cpp
+++ b/hotspot/src/cpu/loongarch/vm/sharedRuntime_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1615,7 +1615,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   const Register oop_handle_reg = S4;
   if (is_critical_native) {
-     __ stop("generate_native_wrapper in sharedRuntime <2>");
+    Unimplemented();
     // check_needs_gc_for_critical_native(masm, stack_slots, total_c_args, total_in_args,
     //                                   oop_handle_offset, oop_maps, in_regs, in_sig_bt);
   }
@@ -1678,7 +1678,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // critical natives they are offset down.
   GrowableArray<int> arg_order(2 * total_in_args);
   VMRegPair tmp_vmreg;
-  tmp_vmreg.set1(T8->as_VMReg());
+  tmp_vmreg.set2(T8->as_VMReg());
 
   if (!is_critical_native) {
     for (int i = total_in_args - 1, c_arg = total_c_args - 1; i >= 0; i--, c_arg--) {
@@ -1687,7 +1687,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     }
   } else {
     // Compute a valid move order, using tmp_vmreg to break any cycles
-     __ stop("generate_native_wrapper in sharedRuntime <2>");
+    Unimplemented();
     // ComputeMoveOrder cmo(total_in_args, in_regs, total_c_args, out_regs, in_sig_bt, arg_order, tmp_vmreg);
   }
 
@@ -1725,7 +1725,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     switch (in_sig_bt[i]) {
       case T_ARRAY:
         if (is_critical_native) {
-          __ stop("generate_native_wrapper in sharedRuntime <2>");
+          Unimplemented();
           // unpack_array_argument(masm, in_regs[i], in_elem_bt[i], out_regs[c_arg + 1], out_regs[c_arg]);
           c_arg++;
 #ifdef ASSERT
@@ -1906,7 +1906,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
   __ st_w(AT, thread, in_bytes(JavaThread::thread_state_offset()));
   // do the call
-  __ call(method->native_function(), relocInfo::runtime_call_type);
+  __ call(native_func, relocInfo::runtime_call_type);
   __ bind(native_return);
 
   oop_maps->add_gc_map(((intptr_t)__ pc()) - start, map);

--- a/hotspot/src/cpu/loongarch/vm/vm_version_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/vm_version_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2020, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -414,6 +414,13 @@ void VM_Version::get_processor_features() {
   // This machine allows unaligned memory accesses
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses, true);
+  }
+
+  if (CriticalJNINatives) {
+    if (FLAG_IS_CMDLINE(CriticalJNINatives)) {
+      warning("CriticalJNINatives specified, but not supported in this VM");
+    }
+    FLAG_SET_DEFAULT(CriticalJNINatives, false);
   }
 }
 

--- a/hotspot/src/cpu/mips/vm/assembler_mips.hpp
+++ b/hotspot/src/cpu/mips/vm/assembler_mips.hpp
@@ -976,11 +976,11 @@ public:
     AbstractAssembler::flush();
   }
 
-  inline void emit_long(int);  // shadows AbstractAssembler::emit_long
-  inline void emit_data(int x) { emit_long(x); }
-  inline void emit_data(int, RelocationHolder const&);
-  inline void emit_data(int, relocInfo::relocType rtype);
-  inline void check_delay();
+  void emit_long(int);  // shadows AbstractAssembler::emit_long
+  void emit_data(int);
+  void emit_data(int, RelocationHolder const&);
+  void emit_data(int, relocInfo::relocType rtype);
+  void check_delay();
 
 
   // Generic instructions

--- a/hotspot/src/cpu/mips/vm/assembler_mips.inline.hpp
+++ b/hotspot/src/cpu/mips/vm/assembler_mips.inline.hpp
@@ -30,28 +30,4 @@
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 
-
-
-inline void Assembler::check_delay() {
-# ifdef CHECK_DELAY
-  guarantee(delay_state != at_delay_slot, "must say delayed() when filling delay slot");
-  delay_state = no_delay;
-# endif
-}
-
-inline void Assembler::emit_long(int x) {
-  check_delay();
-  AbstractAssembler::emit_int32(x);
-}
-
-inline void Assembler::emit_data(int x, relocInfo::relocType rtype) {
-  relocate(rtype);
-  emit_long(x);
-}
-
-inline void Assembler::emit_data(int x, RelocationHolder const& rspec) {
-  relocate(rspec);
-  emit_long(x);
-}
-
 #endif // CPU_MIPS_VM_ASSEMBLER_MIPS_INLINE_HPP

--- a/hotspot/src/cpu/mips/vm/jniFastGetField_mips_64.cpp
+++ b/hotspot/src/cpu/mips/vm/jniFastGetField_mips_64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "code/codeBlob.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"

--- a/hotspot/src/cpu/mips/vm/nativeInst_mips.cpp
+++ b/hotspot/src/cpu/mips/vm/nativeInst_mips.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"

--- a/hotspot/src/cpu/mips/vm/sharedRuntime_mips_64.cpp
+++ b/hotspot/src/cpu/mips/vm/sharedRuntime_mips_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1647,7 +1647,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   const Register oop_handle_reg = S4;
   if (is_critical_native) {
-     __ stop("generate_native_wrapper in sharedRuntime <2>");
+    Unimplemented();
     // check_needs_gc_for_critical_native(masm, stack_slots, total_c_args, total_in_args,
     //                                   oop_handle_offset, oop_maps, in_regs, in_sig_bt);
   }
@@ -1710,7 +1710,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // critical natives they are offset down.
   GrowableArray<int> arg_order(2 * total_in_args);
   VMRegPair tmp_vmreg;
-  tmp_vmreg.set1(T8->as_VMReg());
+  tmp_vmreg.set2(T8->as_VMReg());
 
   if (!is_critical_native) {
     for (int i = total_in_args - 1, c_arg = total_c_args - 1; i >= 0; i--, c_arg--) {
@@ -1719,7 +1719,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     }
   } else {
     // Compute a valid move order, using tmp_vmreg to break any cycles
-     __ stop("generate_native_wrapper in sharedRuntime <2>");
+    Unimplemented();
     // ComputeMoveOrder cmo(total_in_args, in_regs, total_c_args, out_regs, in_sig_bt, arg_order, tmp_vmreg);
   }
 
@@ -1757,7 +1757,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     switch (in_sig_bt[i]) {
       case T_ARRAY:
         if (is_critical_native) {
-          __ stop("generate_native_wrapper in sharedRuntime <2>");
+          Unimplemented();
           // unpack_array_argument(masm, in_regs[i], in_elem_bt[i], out_regs[c_arg + 1], out_regs[c_arg]);
           c_arg++;
 #ifdef ASSERT
@@ -1950,7 +1950,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
   __ sw(AT, thread, in_bytes(JavaThread::thread_state_offset()));
   // do the call
-  __ call(method->native_function(), relocInfo::runtime_call_type);
+  __ call(native_func, relocInfo::runtime_call_type);
   __ delayed()->nop();
   // WARNING - on Windows Java Natives use pascal calling convention and pop the
   // arguments off of the stack. We could just re-adjust the stack pointer here

--- a/hotspot/src/cpu/mips/vm/vm_version_mips.cpp
+++ b/hotspot/src/cpu/mips/vm/vm_version_mips.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -485,6 +485,12 @@ void VM_Version::get_processor_features() {
     UseMontgomerySquareIntrinsic = true;
   }
 
+  if (CriticalJNINatives) {
+    if (FLAG_IS_CMDLINE(CriticalJNINatives)) {
+      warning("CriticalJNINatives specified, but not supported in this VM");
+    }
+    FLAG_SET_DEFAULT(CriticalJNINatives, false);
+  }
 }
 
 void VM_Version::initialize() {

--- a/hotspot/src/os_cpu/linux_loongarch/vm/os_linux_loongarch.cpp
+++ b/hotspot/src/os_cpu/linux_loongarch/vm/os_linux_loongarch.cpp
@@ -324,7 +324,7 @@ JVM_handle_linux_signal(int sig,
 #endif
 
       // Handle signal from NativeJump::patch_verified_entry().
-      if (sig == SIGILL & nativeInstruction_at(pc)->is_sigill_zombie_not_entrant()) {
+      if (sig == SIGILL && nativeInstruction_at(pc)->is_sigill_zombie_not_entrant()) {
 #ifdef PRINT_SIGNAL_HANDLE
         tty->print_cr("verified entry = %lx, sig=%d", nativeInstruction_at(pc), sig);
 #endif

--- a/hotspot/src/os_cpu/linux_mips/vm/os_linux_mips.cpp
+++ b/hotspot/src/os_cpu/linux_mips/vm/os_linux_mips.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ JVM_handle_linux_signal(int sig,
 #endif
 
       // Handle signal from NativeJump::patch_verified_entry().
-      if (sig == SIGILL & nativeInstruction_at(pc)->is_sigill_zombie_not_entrant()) {
+      if (sig == SIGILL && nativeInstruction_at(pc)->is_sigill_zombie_not_entrant()) {
 #ifdef PRINT_SIGNAL_HANDLE
         tty->print_cr("verified entry = %lx, sig=%d", nativeInstruction_at(pc), sig);
 #endif

--- a/hotspot/src/share/vm/asm/codeBuffer.cpp
+++ b/hotspot/src/share/vm/asm/codeBuffer.cpp
@@ -23,8 +23,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2021. These
- * modifications are Copyright (c) 2015, 2021, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2015, 2023, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -329,9 +329,7 @@ void CodeSection::relocate(address at, RelocationHolder const& spec, int format)
     assert(rtype == relocInfo::none              ||
            rtype == relocInfo::runtime_call_type ||
            rtype == relocInfo::internal_word_type||
-#if defined MIPS && !defined ZERO
-           rtype == relocInfo::internal_pc_type  ||
-#endif
+           NOT_ZERO(MIPS64_ONLY(rtype == relocInfo::internal_pc_type ||))
            rtype == relocInfo::section_word_type ||
            rtype == relocInfo::external_word_type,
            "code needs relocation information");

--- a/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
+++ b/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
@@ -44,14 +44,14 @@ echo "Testing on " $OS
 case "$OS" in
   Linux)
     cc_cmd=`which gcc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
     ;;
   Solaris)
     cc_cmd=`which cc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: cc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -63,7 +63,7 @@ case "$OS" in
 esac
 
 # CriticalJNINatives is not supported for aarch64
-if [ $VM_CPU == "aarch64" ]; then
+if [ $VM_CPU = "aarch64" ]; then
     echo "Test Passed"
     exit 0;
 fi

--- a/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
+++ b/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
@@ -24,6 +24,12 @@
 #  questions.
 #
 
+#
+# This file has been modified by Loongson Technology in 2023. These
+# modifications are Copyright (c) 2023, Loongson Technology, and are made
+# available on the same license terms set forth above.
+#
+
 ## @test Test8167409.sh
 ## @bug 8167409
 ## @summary Invalid value passed to critical JNI function
@@ -66,6 +72,18 @@ esac
 if [ $VM_CPU = "aarch64" ]; then
     echo "Test Passed"
     exit 0;
+fi
+
+# CriticalJNINatives is not supported for loongarch64
+if [ $VM_CPU = "loongarch64" ]; then
+     echo "Test Passed"
+     exit 0;
+fi
+
+# CriticalJNINatives is not supported for mips64
+if [ $VM_CPU = "mips64" -o $VM_CPU = "mips64el" ]; then
+     echo "Test Passed"
+     exit 0;
 fi
 
 THIS_DIR=.

--- a/hotspot/test/compiler/floatingpoint/8165673/TestFloatJNIArgs.sh
+++ b/hotspot/test/compiler/floatingpoint/8165673/TestFloatJNIArgs.sh
@@ -41,10 +41,10 @@ echo "TESTSRC=${TESTSRC}"
 . ${TESTSRC}/../../../test_env.sh
 
 # set platform-dependent variables
-if [ $VM_OS == "linux" -a $VM_CPU == "aarch64" ]; then
+if [ $VM_OS = "linux" -a $VM_CPU = "aarch64" ]; then
     echo "Testing on linux-aarch64"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi

--- a/hotspot/test/compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh
+++ b/hotspot/test/compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh
@@ -41,10 +41,10 @@ echo "TESTSRC=${TESTSRC}"
 . ${TESTSRC}/../../../test_env.sh
 
 # set platform-dependent variables
-if [ $VM_OS == "linux" -a $VM_CPU == "aarch64" ]; then
+if [ $VM_OS = "linux" -a $VM_CPU = "aarch64" ]; then
     echo "Testing on linux-aarch64"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi

--- a/hotspot/test/runtime/7107135/Test7107135.sh
+++ b/hotspot/test/runtime/7107135/Test7107135.sh
@@ -47,7 +47,7 @@ case "$OS" in
   Linux)
     echo "Testing on Linux"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -88,7 +88,7 @@ echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} Test test-rwx
 ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} Test test-rwx
 JAVA_RETVAL=$?
 
-if [ "$JAVA_RETVAL" == "0" ]
+if [ "$JAVA_RETVAL" = "0" ]
 then
   echo
   echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} TestMT test-rwx

--- a/hotspot/test/runtime/StackGap/testme.sh
+++ b/hotspot/test/runtime/StackGap/testme.sh
@@ -49,19 +49,6 @@ if [ "x$gcc_cmd" = "x" ]; then
     exit 0;
 fi
 
-PLATFORM=$(echo ${VM_CPU})
-case "$PLATFORM" in
-  mips64el )
-    CFLAGS="-mabi=${VM_BITS}"
-    ;;
-  loongarch64 )
-    CFLAGS="-mabi=lp${VM_BITS}"
-    ;;
-  * )
-    CFLAGS="-m${VM_BITS}"
-    ;;
-esac
-
 LD_LIBRARY_PATH=.:${COMPILEJAVA}/jre/lib/${VM_CPU}/${VM_TYPE}:/usr/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH
 

--- a/hotspot/test/runtime/jni/CallWithJNIWeak/test.sh
+++ b/hotspot/test/runtime/jni/CallWithJNIWeak/test.sh
@@ -45,14 +45,14 @@ echo "Testing on " $OS
 case "$OS" in
   Linux)
     cc_cmd=`which gcc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
     ;;
   Solaris)
     cc_cmd=`which cc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: cc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -81,7 +81,7 @@ echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint CallWithJNIWeak
 ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint CallWithJNIWeak
 JAVA_RETVAL=$?
 
-if [ "$JAVA_RETVAL" == "0" ]
+if [ "$JAVA_RETVAL" = "0" ]
 then
   echo
   echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xcomp CallWithJNIWeak

--- a/hotspot/test/runtime/jni/ReturnJNIWeak/test.sh
+++ b/hotspot/test/runtime/jni/ReturnJNIWeak/test.sh
@@ -45,14 +45,14 @@ echo "Testing on " $OS
 case "$OS" in
   Linux)
     cc_cmd=`which gcc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
     ;;
   Solaris)
     cc_cmd=`which cc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: cc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -81,7 +81,7 @@ echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint ReturnJNIWeak
 ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint ReturnJNIWeak
 JAVA_RETVAL=$?
 
-if [ "$JAVA_RETVAL" == "0" ]
+if [ "$JAVA_RETVAL" = "0" ]
 then
   echo
   echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xcomp ReturnJNIWeak


### PR DESCRIPTION
18662: Fixed - 'Disassembler' has not been declared
12751: [8u] compiler/criticalnatives/argumentcorruption/Test8167409.sh fail
29675: windows debug build failed
29680: 8299804: Fix non-portable code in hotspot shell tests in 8u
28682: [MIPS] Fix a typo in PosixSignals::pd_hotspot_signal_handler
28678: Fix a typo in PosixSignals::pd_hotspot_signal_handler
29646: LA/MIPS port of 8296959: Fix hotspot shell tests of 8u on multilib systems