### PR TITLE
Update (2023.05.17)

### DIFF
--- a/common/autoconf/spec.gmk.in
+++ b/common/autoconf/spec.gmk.in
@@ -231,7 +231,7 @@ BUILDER_NAME:=@BUILDER_NAME@
 HOST_NAME:=@HOST_NAME@
 
 # Loongson OpenJDK Version info
-VER=8.1.13
+VER=8.1.14
 ifeq ($(HOST_NAME), )
   HOST_NAME=unknown
 endif

--- a/hotspot/test/runtime/Unsafe/RangeCheck.java
+++ b/hotspot/test/runtime/Unsafe/RangeCheck.java
@@ -43,6 +43,7 @@ public class RangeCheck {
                 true,
                 "-Xmx32m",
                 "-XX:-TransmitErrorReport",
+                "-XX:-InlineUnsafeOps", // The compiler intrinsics doesn't have the assert
                 DummyClassWithMainRangeCheck.class.getName());
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
29901: runtime/Unsafe/RangeCheck.java fail with -Xcomp
30296: start of release updates for Loongson OpenJDK 8.1.14