### PR TITLE
Update (2023.07.03)

### DIFF
--- a/common/autoconf/spec.gmk.in
+++ b/common/autoconf/spec.gmk.in
@@ -231,7 +231,7 @@ BUILDER_NAME:=@BUILDER_NAME@
 HOST_NAME:=@HOST_NAME@
 
 # Loongson OpenJDK Version info
-VER=8.1.14
+VER=8.1.15
 ifeq ($(HOST_NAME), )
   HOST_NAME=unknown
 endif

--- a/hotspot/src/cpu/loongarch/vm/assembler_loongarch.hpp
+++ b/hotspot/src/cpu/loongarch/vm/assembler_loongarch.hpp
@@ -2019,19 +2019,25 @@ public:
   void bceqz(ConditionalFlagRegister cj, Label& L)     { bceqz(cj, target(L)); }
   void bcnez(ConditionalFlagRegister cj, Label& L)     { bcnez(cj, target(L)); }
 
-  //1. Now Membar_mask_bits is 0,Need to fix it after LA6000
-  //2. Also to fix *prev & 0x7FFF)== hin in MacroAssembler::membar(Membar_mask_bits hint)
   typedef enum {
-    StoreStore = 0,
-    LoadStore  = 0,
-    StoreLoad  = 0,
-    LoadLoad   = 0,
-    AnyAny     = 0
+    // hint[4]
+    Completion = 0,
+    Ordering   = (1 << 4),
+
+    // The bitwise-not of the below constants is corresponding to the hint. This is convenient for OR operation.
+    // hint[3:2] and hint[1:0]
+    LoadLoad   = ((1 << 3) | (1 << 1)),
+    LoadStore  = ((1 << 3) | (1 << 0)),
+    StoreLoad  = ((1 << 2) | (1 << 1)),
+    StoreStore = ((1 << 2) | (1 << 0)),
+    AnyAny     = ((3 << 2) | (3 << 0)),
   } Membar_mask_bits;
 
   // Serializes memory and blows flags
   void membar(Membar_mask_bits hint) {
-    dbar(hint);
+    assert((hint & (3 << 0)) != 0, "membar mask unsupported!");
+    assert((hint & (3 << 2)) != 0, "membar mask unsupported!");
+    dbar(Ordering | (~hint & 0xf));
   }
 
   // LSX and LASX

--- a/hotspot/src/cpu/loongarch/vm/c1_MacroAssembler_loongarch_64.cpp
+++ b/hotspot/src/cpu/loongarch/vm/c1_MacroAssembler_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,7 +241,7 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
      }
   }
 
-  dbar(0);
+  membar(StoreStore);
 
   if (CURRENT_ENV->dtrace_alloc_probes()) {
     assert(obj == A0, "must be");
@@ -276,7 +276,7 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
   // clear rest of allocated space
   initialize_body(obj, arr_size, header_size * BytesPerWord, t1, t2);
 
-  dbar(0);
+  membar(StoreStore);
 
   if (CURRENT_ENV->dtrace_alloc_probes()) {
     assert(obj == A0, "must be");

--- a/hotspot/src/cpu/loongarch/vm/macroAssembler_loongarch.cpp
+++ b/hotspot/src/cpu/loongarch/vm/macroAssembler_loongarch.cpp
@@ -1972,7 +1972,7 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
 
   bind(fail);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, resflag);
   move(resflag, R0);
@@ -1995,7 +1995,7 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
 
   bind(neq);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, tmp);
   if (fail)
@@ -2020,7 +2020,7 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval,
 
   bind(fail);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, resflag);
   move(resflag, R0);
@@ -2045,7 +2045,7 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval, R
 
   bind(neq);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, tmp);
   if (fail)
@@ -2422,7 +2422,7 @@ void MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register resR
       move(AT, R0);
       bnez(scrReg, DONE_SET);
 
-      membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
+      membar(Assembler::Membar_mask_bits(LoadStore|StoreStore)); // release-store
       st_d(R0, Address(tmpReg, ObjectMonitor::owner_offset_in_bytes() - 2));
       li(resReg, 1);
       b(DONE);

--- a/hotspot/src/os_cpu/linux_loongarch/vm/atomic_linux_loongarch.inline.hpp
+++ b/hotspot/src/os_cpu/linux_loongarch/vm/atomic_linux_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2020, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ inline jint     Atomic::cmpxchg    (jint     exchange_value, volatile jint*     
       "   sc.w  %[__cmp],  %[__dest]  \n\t"
       "   beqz  %[__cmp],  1b    \n\t"
       "2:        \n\t"
-      "   dbar 0        \n\t"
+      "   dbar 0x700        \n\t"
 
       : [__prev] "=&r" (__prev), [__cmp] "=&r" (__cmp)
       : [__dest] "ZC" (*(volatile jint*)dest), [__old] "r" (compare_value),  [__new] "r" (exchange_value)
@@ -170,7 +170,7 @@ inline jlong    Atomic::cmpxchg    (jlong    exchange_value, volatile jlong*    
       "   sc.d  %[__cmp],  %[__dest]  \n\t"
       "   beqz  %[__cmp],  1b    \n\t"
       "2:        \n\t"
-      "   dbar 0 \n\t"
+      "   dbar 0x700 \n\t"
 
       : [__prev] "=&r" (__prev), [__cmp] "=&r" (__cmp)
       : [__dest] "ZC" (*(volatile jlong*)dest), [__old] "r" (compare_value),  [__new] "r" (exchange_value)
@@ -189,7 +189,7 @@ inline intptr_t Atomic::cmpxchg_ptr(intptr_t exchange_value, volatile intptr_t* 
       "   sc.d  %[__cmp],  %[__dest]  \n\t"
       "   beqz  %[__cmp],  1b    \n\t"
       "2:        \n\t"
-      "   dbar  0 \n\t"
+      "   dbar  0x700 \n\t"
 
       : [__prev] "=&r" (__prev), [__cmp] "=&r" (__cmp)
       : [__dest] "ZC" (*(volatile intptr_t*)dest), [__old] "r" (compare_value),  [__new] "r" (exchange_value)

--- a/hotspot/src/os_cpu/linux_loongarch/vm/orderAccess_linux_loongarch.inline.hpp
+++ b/hotspot/src/os_cpu/linux_loongarch/vm/orderAccess_linux_loongarch.inline.hpp
@@ -31,19 +31,19 @@
 #include "runtime/os.hpp"
 #include "vm_version_loongarch.hpp"
 
-#define inlasm_sync() if (os::is_ActiveCoresMP()) \
+#define inlasm_sync(v) if (os::is_ActiveCoresMP()) \
                         __asm__ __volatile__ ("nop"   : : : "memory"); \
                       else \
-                        __asm__ __volatile__ ("dbar 0"   : : : "memory");
+                        __asm__ __volatile__ ("dbar %0"   : :"K"(v) : "memory");
 
-inline void OrderAccess::loadload()   { inlasm_sync(); }
-inline void OrderAccess::storestore() { inlasm_sync(); }
-inline void OrderAccess::loadstore()  { inlasm_sync(); }
-inline void OrderAccess::storeload()  { inlasm_sync(); }
+inline void OrderAccess::loadload()   { inlasm_sync(0x15); }
+inline void OrderAccess::storestore() { inlasm_sync(0x1a); }
+inline void OrderAccess::loadstore()  { inlasm_sync(0x16); }
+inline void OrderAccess::storeload()  { inlasm_sync(0x19); }
 
-inline void OrderAccess::acquire() { inlasm_sync(); }
-inline void OrderAccess::release() { inlasm_sync(); }
-inline void OrderAccess::fence()   { inlasm_sync(); }
+inline void OrderAccess::acquire() { inlasm_sync(0x14); }
+inline void OrderAccess::release() { inlasm_sync(0x12); }
+inline void OrderAccess::fence()   { inlasm_sync(0x10); }
 
 //implementation of load_acquire
 inline jbyte    OrderAccess::load_acquire(volatile jbyte*   p) { jbyte data = *p; acquire(); return data; }


### PR DESCRIPTION
31215: start of release updates for Loongson OpenJDK 8.1.15
30358: Add support for ordering memory barriers