### PR TITLE
Update (2023.08.14)

### DIFF
--- a/common/autoconf/spec.gmk.in
+++ b/common/autoconf/spec.gmk.in
@@ -231,7 +231,7 @@ BUILDER_NAME:=@BUILDER_NAME@
 HOST_NAME:=@HOST_NAME@
 
 # Loongson OpenJDK Version info
-VER=8.1.15
+VER=8.1.16
 ifeq ($(HOST_NAME), )
   HOST_NAME=unknown
 endif

--- a/hotspot/src/cpu/loongarch/vm/loongarch_64.ad
+++ b/hotspot/src/cpu/loongarch/vm/loongarch_64.ad
@@ -10631,14 +10631,25 @@ instruct cmpFastUnlock(FlagsReg cr, mRegP object, mRegP box, mRegI tmp, mRegI sc
 %}
 
 // Store CMS card-mark Immediate 0
+instruct storeImmCM_order(memory mem, immI_0 zero) %{
+  match(Set mem (StoreCM mem zero));
+  predicate(UseConcMarkSweepGC && !UseCondCardMark);
+  ins_cost(100);
+  format %{ "StoreCM MEMBAR storestore\n\t"
+            "st_b   $mem, zero\t! card-mark imm0" %}
+  ins_encode %{
+    __ membar(__ StoreStore);
+    __ loadstore_enc(R0, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, MacroAssembler::STORE_BYTE);
+  %}
+  ins_pipe( ialu_storeI );
+%}
+
 instruct storeImmCM(memory mem, immI_0 zero) %{
   match(Set mem (StoreCM mem zero));
 
   ins_cost(150);
-  format %{ "StoreCM MEMBAR loadstore\n\t"
-            "st_b   $mem, zero\t! CMS card-mark imm0" %}
+  format %{ "st_b   $mem, zero\t! card-mark imm0" %}
   ins_encode %{
-    __ membar(__ StoreStore);
     __ loadstore_enc(R0, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, MacroAssembler::STORE_BYTE);
   %}
   ins_pipe( ialu_storeI );

--- a/hotspot/src/cpu/loongarch/vm/stubGenerator_loongarch_64.cpp
+++ b/hotspot/src/cpu/loongarch/vm/stubGenerator_loongarch_64.cpp
@@ -803,7 +803,7 @@ class StubGenerator: public StubCodeGenerator {
           const Register end = count;
 
           if (UseConcMarkSweepGC) {
-            __ membar(__ StoreLoad);
+            __ membar(__ StoreStore);
           }
 
           int64_t disp = (int64_t) ct->byte_map_base;


### PR DESCRIPTION
31482: StoreStore only be used for CMS with no conditional card marking
31484: Fix a typo StoreLoad to StoreStore
31447: start of release updates for Loongson OpenJDK 8.1.16