### PR TITLE
Update (2025.02.08)

### DIFF
--- a/common/autoconf/spec.gmk.in
+++ b/common/autoconf/spec.gmk.in
@@ -231,7 +231,7 @@ BUILDER_NAME:=@BUILDER_NAME@
 HOST_NAME:=@HOST_NAME@
 
 # Loongson OpenJDK Version info
-VER=8.1.21
+VER=8.1.22
 ifeq ($(HOST_NAME), )
   HOST_NAME=unknown
 endif


### PR DESCRIPTION
35217: start of release updates for Loongson OpenJDK 8.1.22